### PR TITLE
fixed 1.20.5 and 1.21 and 1.21.3 pulling incorrect materials.json data

### DIFF
--- a/mc/1.20.5/src/main/java/dev/u9g/minecraftdatagenerator/generators/MaterialsDataGenerator.java
+++ b/mc/1.20.5/src/main/java/dev/u9g/minecraftdatagenerator/generators/MaterialsDataGenerator.java
@@ -137,6 +137,7 @@ public class MaterialsDataGenerator implements IDataGenerator {
         Map<String, Map<Item, Float>> materialMiningSpeeds = new LinkedHashMap<>();
         materialMiningSpeeds.put("default", ImmutableMap.of());
 
+        //Special materials used for shears and swords special mining speed logic
         Map<Item, Float> leavesMaterialSpeeds = new LinkedHashMap<>();
         Map<Item, Float> cowebMaterialSpeeds = new LinkedHashMap<>();
         Map<Item, Float> plantMaterialSpeeds = new LinkedHashMap<>();
@@ -147,6 +148,7 @@ public class MaterialsDataGenerator implements IDataGenerator {
         materialMiningSpeeds.put("plant", plantMaterialSpeeds);
         materialMiningSpeeds.put("gourd", gourdMaterialSpeeds);
 
+        //Shears need special handling because they do not follow normal rules like tools
         leavesMaterialSpeeds.put(Items.SHEARS, 15.0f);
         cowebMaterialSpeeds.put(Items.SHEARS, 15.0f);
         materialMiningSpeeds.put("vine_or_glow_lichen", ImmutableMap.of(Items.SHEARS, 2.0f));

--- a/mc/1.21.3/src/main/java/dev/u9g/minecraftdatagenerator/generators/MaterialsDataGenerator.java
+++ b/mc/1.21.3/src/main/java/dev/u9g/minecraftdatagenerator/generators/MaterialsDataGenerator.java
@@ -35,6 +35,30 @@ public class MaterialsDataGenerator implements IDataGenerator {
             .add(ImmutableList.of("vine_or_glow_lichen", "plant", makeMaterialNameForTag(BlockTags.AXE_MINEABLE)
             )).build();
 
+    private static final Map<String, Float> TOOL_SPEEDS = new HashMap<>() {{
+        // Base speeds for each tool type
+        put("wooden", 2.0f);
+        put("stone", 4.0f);
+        put("iron", 6.0f);
+        put("diamond", 8.0f);
+        put("netherite", 9.0f);
+        put("golden", 12.0f);
+    }};
+
+    private static float getToolSpeed(Item item) {
+        String itemName = item.toString().toLowerCase();
+        // Remove minecraft: prefix if present
+        if (itemName.startsWith("minecraft:")) {
+            itemName = itemName.substring("minecraft:".length());
+        }
+        for (Map.Entry<String, Float> entry : TOOL_SPEEDS.entrySet()) {
+            if (itemName.startsWith(entry.getKey())) {
+                return entry.getValue();
+            }
+        }
+        return 1.0f;
+    }
+
     private static String makeMaterialNameForTag(TagKey<Block> tag) {
         return tag.id().getPath();
     }
@@ -144,8 +168,8 @@ public class MaterialsDataGenerator implements IDataGenerator {
                                         String materialName = makeMaterialNameForTag(tagKey.get());
 
                                         Map<Item, Float> materialSpeeds = materialMiningSpeeds.computeIfAbsent(materialName, k -> new LinkedHashMap<>());
-                                        float miningSpeed = item.getComponents().get(DataComponentTypes.TOOL).defaultMiningSpeed();
-                                        materialSpeeds.put(item, miningSpeed);
+                                        float baseSpeed = getToolSpeed(item);
+                                        materialSpeeds.put(item, baseSpeed);
                                     }
                                 }
                         );


### PR DESCRIPTION
Fixed incorrect mining speeds in materials.json for 1.20.5, 1.21.1 and 1.21.3 by switching from using the tool component's defaultMiningSpeed() which pulls incorrect values for some reason past 1.20.4, to using predefined mining speed values for each tool tier. before it was pulling incorrect default values (1.0) from the tool components, they are hardcoded now which isnt ideal but it fixes it for now since i couldnt find another way to pull the correct values.