### PR TITLE
Liquids cannot be mined

### DIFF
--- a/mc/1.13/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
+++ b/mc/1.13/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
@@ -7,6 +7,8 @@ import dev.u9g.minecraftdatagenerator.mixin.MiningToolItemAccessor;
 import dev.u9g.minecraftdatagenerator.util.DGU;
 import dev.u9g.minecraftdatagenerator.util.EmptyBlockView;
 import net.minecraft.block.AirBlock;
+import net.minecraft.block.FluidBlock;
+import net.minecraft.block.BubbleColumnBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.item.Item;
@@ -94,7 +96,8 @@ public class BlocksDataGenerator implements IDataGenerator {
         blockDesc.addProperty("hardness", hardness);
         blockDesc.addProperty("resistance", block.getBlastResistance());
         blockDesc.addProperty("stackSize", block.getItem().getMaxCount());
-        blockDesc.addProperty("diggable", hardness != -1.0f && !(block instanceof AirBlock));
+        boolean nonTargetable = block instanceof AirBlock || block instanceof FluidBlock || block instanceof BubbleColumnBlock;
+        blockDesc.addProperty("diggable", hardness != -1.0f && !nonTargetable);
         JsonObject effTools = new JsonObject();
         effectiveTools.forEach(item -> effTools.addProperty(
                 String.valueOf(Registry.ITEM.getRawId(item)), // key

--- a/mc/1.14/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
+++ b/mc/1.14/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
@@ -6,6 +6,8 @@ import com.google.gson.JsonObject;
 import dev.u9g.minecraftdatagenerator.mixin.MiningToolItemAccessor;
 import dev.u9g.minecraftdatagenerator.util.DGU;
 import net.minecraft.block.AirBlock;
+import net.minecraft.block.FluidBlock;
+import net.minecraft.block.BubbleColumnBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.item.Item;
@@ -103,7 +105,8 @@ public class BlocksDataGenerator implements IDataGenerator {
         blockDesc.addProperty("hardness", hardness);
         blockDesc.addProperty("resistance", block.getBlastResistance());
         blockDesc.addProperty("stackSize", block.asItem().getMaxAmount());
-        blockDesc.addProperty("diggable", hardness != -1.0f && !(block instanceof AirBlock));
+        boolean nonTargetable = block instanceof AirBlock || block instanceof FluidBlock || block instanceof BubbleColumnBlock;
+        blockDesc.addProperty("diggable", hardness != -1.0f && !nonTargetable);
         JsonObject effTools = new JsonObject();
         effectiveTools.forEach(item -> effTools.addProperty(
                 String.valueOf(Registry.ITEM.getRawId(item)), // key

--- a/mc/1.15/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
+++ b/mc/1.15/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
@@ -6,6 +6,8 @@ import com.google.gson.JsonObject;
 import dev.u9g.minecraftdatagenerator.mixin.MiningToolItemAccessor;
 import dev.u9g.minecraftdatagenerator.util.DGU;
 import net.minecraft.block.AirBlock;
+import net.minecraft.block.FluidBlock;
+import net.minecraft.block.BubbleColumnBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.item.Item;
@@ -98,7 +100,8 @@ public class BlocksDataGenerator implements IDataGenerator {
         blockDesc.addProperty("hardness", hardness);
         blockDesc.addProperty("resistance", block.getBlastResistance());
         blockDesc.addProperty("stackSize", block.asItem().getMaxCount());
-        blockDesc.addProperty("diggable", hardness != -1.0f && !(block instanceof AirBlock));
+        boolean nonTargetable = block instanceof AirBlock || block instanceof FluidBlock || block instanceof BubbleColumnBlock;
+        blockDesc.addProperty("diggable", hardness != -1.0f && !nonTargetable);
         JsonObject effTools = new JsonObject();
         effectiveTools.forEach(item -> effTools.addProperty(
                 String.valueOf(Registry.ITEM.getRawId(item)), // key

--- a/mc/1.16/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
+++ b/mc/1.16/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
@@ -6,6 +6,8 @@ import com.google.gson.JsonObject;
 import dev.u9g.minecraftdatagenerator.mixin.MiningToolItemAccessor;
 import dev.u9g.minecraftdatagenerator.util.DGU;
 import net.minecraft.block.AirBlock;
+import net.minecraft.block.FluidBlock;
+import net.minecraft.block.BubbleColumnBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.item.Item;
@@ -105,7 +107,8 @@ public class BlocksDataGenerator implements IDataGenerator {
         blockDesc.addProperty("hardness", hardness);
         blockDesc.addProperty("resistance", block.getBlastResistance());
         blockDesc.addProperty("stackSize", block.asItem().getMaxCount());
-        blockDesc.addProperty("diggable", hardness != -1.0f && !(block instanceof AirBlock));
+        boolean nonTargetable = block instanceof AirBlock || block instanceof FluidBlock || block instanceof BubbleColumnBlock;
+        blockDesc.addProperty("diggable", hardness != -1.0f && !nonTargetable);
         JsonObject effTools = new JsonObject();
         effectiveTools.forEach(item -> effTools.addProperty(
                 String.valueOf(Registry.ITEM.getRawId(item)), // key

--- a/mc/1.17/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
+++ b/mc/1.17/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
@@ -5,6 +5,8 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import dev.u9g.minecraftdatagenerator.util.DGU;
 import net.minecraft.block.AirBlock;
+import net.minecraft.block.FluidBlock;
+import net.minecraft.block.BubbleColumnBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.item.Item;
@@ -134,7 +136,8 @@ public class BlocksDataGenerator implements IDataGenerator {
         blockDesc.addProperty("hardness", block.getHardness());
         blockDesc.addProperty("resistance", block.getBlastResistance());
         blockDesc.addProperty("stackSize", block.asItem().getMaxCount());
-        blockDesc.addProperty("diggable", block.getHardness() != -1.0f && !(block instanceof AirBlock));
+        boolean nonTargetable = block instanceof AirBlock || block instanceof FluidBlock || block instanceof BubbleColumnBlock;
+        blockDesc.addProperty("diggable", block.getHardness() != -1.0f && !nonTargetable);
 //        JsonObject effTools = new JsonObject();
 //        effectiveTools.forEach(item -> effTools.addProperty(
 //                String.valueOf(Registry.ITEM.getRawId(item)), // key

--- a/mc/1.18/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
+++ b/mc/1.18/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
@@ -5,6 +5,8 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import dev.u9g.minecraftdatagenerator.util.DGU;
 import net.minecraft.block.AirBlock;
+import net.minecraft.block.FluidBlock;
+import net.minecraft.block.BubbleColumnBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.item.Item;
@@ -147,7 +149,8 @@ public class BlocksDataGenerator implements IDataGenerator {
         // }
         JsonArray dropsArray = new JsonArray();
         blockDesc.add("drops", dropsArray);
-        blockDesc.addProperty("diggable", block.getHardness() != -1.0f && !(block instanceof AirBlock));
+        boolean nonTargetable = block instanceof AirBlock || block instanceof FluidBlock || block instanceof BubbleColumnBlock;
+        blockDesc.addProperty("diggable", block.getHardness() != -1.0f && !nonTargetable);
         blockDesc.addProperty("transparent", !defaultState.isOpaque());
         blockDesc.addProperty("filterLight", defaultState.getOpacity(EmptyBlockView.INSTANCE, BlockPos.ORIGIN));
         blockDesc.addProperty("emitLight", defaultState.getLuminance());

--- a/mc/1.19.2/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
+++ b/mc/1.19.2/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
@@ -5,6 +5,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import dev.u9g.minecraftdatagenerator.util.DGU;
 import net.minecraft.block.AirBlock;
+import net.minecraft.block.FluidBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.item.Item;
@@ -134,7 +135,7 @@ public class BlocksDataGenerator implements IDataGenerator {
         blockDesc.addProperty("hardness", block.getHardness());
         blockDesc.addProperty("resistance", block.getBlastResistance());
         blockDesc.addProperty("stackSize", block.asItem().getMaxCount());
-        blockDesc.addProperty("diggable", block.getHardness() != -1.0f && !(block instanceof AirBlock));
+        blockDesc.addProperty("diggable", block.getHardness() != -1.0f && !(block instanceof AirBlock) && !(block instanceof FluidBlock));
 //        JsonObject effTools = new JsonObject();
 //        effectiveTools.forEach(item -> effTools.addProperty(
 //                String.valueOf(Registry.ITEM.getRawId(item)), // key

--- a/mc/1.19.2/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
+++ b/mc/1.19.2/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
@@ -6,6 +6,7 @@ import com.google.gson.JsonObject;
 import dev.u9g.minecraftdatagenerator.util.DGU;
 import net.minecraft.block.AirBlock;
 import net.minecraft.block.FluidBlock;
+import net.minecraft.block.BubbleColumnBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.item.Item;
@@ -135,7 +136,8 @@ public class BlocksDataGenerator implements IDataGenerator {
         blockDesc.addProperty("hardness", block.getHardness());
         blockDesc.addProperty("resistance", block.getBlastResistance());
         blockDesc.addProperty("stackSize", block.asItem().getMaxCount());
-        blockDesc.addProperty("diggable", block.getHardness() != -1.0f && !(block instanceof AirBlock) && !(block instanceof FluidBlock));
+        boolean nonTargetable = block instanceof AirBlock || block instanceof FluidBlock || block instanceof BubbleColumnBlock;
+        blockDesc.addProperty("diggable", block.getHardness() != -1.0f && !nonTargetable);
 //        JsonObject effTools = new JsonObject();
 //        effectiveTools.forEach(item -> effTools.addProperty(
 //                String.valueOf(Registry.ITEM.getRawId(item)), // key

--- a/mc/1.19/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
+++ b/mc/1.19/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
@@ -5,6 +5,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import dev.u9g.minecraftdatagenerator.util.DGU;
 import net.minecraft.block.AirBlock;
+import net.minecraft.block.FluidBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.item.Item;
@@ -134,7 +135,7 @@ public class BlocksDataGenerator implements IDataGenerator {
         blockDesc.addProperty("hardness", block.getHardness());
         blockDesc.addProperty("resistance", block.getBlastResistance());
         blockDesc.addProperty("stackSize", block.asItem().getMaxCount());
-        blockDesc.addProperty("diggable", block.getHardness() != -1.0f && !(block instanceof AirBlock));
+        blockDesc.addProperty("diggable", block.getHardness() != -1.0f && !(block instanceof AirBlock) && !(block instanceof FluidBlock));
 //        JsonObject effTools = new JsonObject();
 //        effectiveTools.forEach(item -> effTools.addProperty(
 //                String.valueOf(Registry.ITEM.getRawId(item)), // key

--- a/mc/1.19/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
+++ b/mc/1.19/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
@@ -6,6 +6,7 @@ import com.google.gson.JsonObject;
 import dev.u9g.minecraftdatagenerator.util.DGU;
 import net.minecraft.block.AirBlock;
 import net.minecraft.block.FluidBlock;
+import net.minecraft.block.BubbleColumnBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.item.Item;
@@ -135,7 +136,8 @@ public class BlocksDataGenerator implements IDataGenerator {
         blockDesc.addProperty("hardness", block.getHardness());
         blockDesc.addProperty("resistance", block.getBlastResistance());
         blockDesc.addProperty("stackSize", block.asItem().getMaxCount());
-        blockDesc.addProperty("diggable", block.getHardness() != -1.0f && !(block instanceof AirBlock) && !(block instanceof FluidBlock));
+        boolean nonTargetable = block instanceof AirBlock || block instanceof FluidBlock || block instanceof BubbleColumnBlock;
+        blockDesc.addProperty("diggable", block.getHardness() != -1.0f && !nonTargetable);
 //        JsonObject effTools = new JsonObject();
 //        effectiveTools.forEach(item -> effTools.addProperty(
 //                String.valueOf(Registry.ITEM.getRawId(item)), // key

--- a/mc/1.20.4/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
+++ b/mc/1.20.4/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
@@ -5,6 +5,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import dev.u9g.minecraftdatagenerator.util.DGU;
 import net.minecraft.block.AirBlock;
+import net.minecraft.block.FluidBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.item.Item;
@@ -134,7 +135,7 @@ public class BlocksDataGenerator implements IDataGenerator {
         blockDesc.addProperty("hardness", block.getHardness());
         blockDesc.addProperty("resistance", block.getBlastResistance());
         blockDesc.addProperty("stackSize", block.asItem().getMaxCount());
-        blockDesc.addProperty("diggable", block.getHardness() != -1.0f && !(block instanceof AirBlock));
+        blockDesc.addProperty("diggable", block.getHardness() != -1.0f && !(block instanceof AirBlock) && !(block instanceof FluidBlock));
 //        JsonObject effTools = new JsonObject();
 //        effectiveTools.forEach(item -> effTools.addProperty(
 //                String.valueOf(Registry.ITEM.getRawId(item)), // key

--- a/mc/1.20.4/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
+++ b/mc/1.20.4/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
@@ -6,6 +6,7 @@ import com.google.gson.JsonObject;
 import dev.u9g.minecraftdatagenerator.util.DGU;
 import net.minecraft.block.AirBlock;
 import net.minecraft.block.FluidBlock;
+import net.minecraft.block.BubbleColumnBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.item.Item;
@@ -135,7 +136,8 @@ public class BlocksDataGenerator implements IDataGenerator {
         blockDesc.addProperty("hardness", block.getHardness());
         blockDesc.addProperty("resistance", block.getBlastResistance());
         blockDesc.addProperty("stackSize", block.asItem().getMaxCount());
-        blockDesc.addProperty("diggable", block.getHardness() != -1.0f && !(block instanceof AirBlock) && !(block instanceof FluidBlock));
+        boolean nonTargetable = block instanceof AirBlock || block instanceof FluidBlock || block instanceof BubbleColumnBlock;
+        blockDesc.addProperty("diggable", block.getHardness() != -1.0f && !nonTargetable);
 //        JsonObject effTools = new JsonObject();
 //        effectiveTools.forEach(item -> effTools.addProperty(
 //                String.valueOf(Registry.ITEM.getRawId(item)), // key

--- a/mc/1.20.5/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
+++ b/mc/1.20.5/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
@@ -5,6 +5,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import dev.u9g.minecraftdatagenerator.util.DGU;
 import net.minecraft.block.AirBlock;
+import net.minecraft.block.FluidBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.item.Item;
@@ -134,7 +135,7 @@ public class BlocksDataGenerator implements IDataGenerator {
         blockDesc.addProperty("hardness", block.getHardness());
         blockDesc.addProperty("resistance", block.getBlastResistance());
         blockDesc.addProperty("stackSize", block.asItem().getMaxCount());
-        blockDesc.addProperty("diggable", block.getHardness() != -1.0f && !(block instanceof AirBlock));
+        blockDesc.addProperty("diggable", block.getHardness() != -1.0f && !(block instanceof AirBlock) && !(block instanceof FluidBlock));
 //        JsonObject effTools = new JsonObject();
 //        effectiveTools.forEach(item -> effTools.addProperty(
 //                String.valueOf(Registry.ITEM.getRawId(item)), // key

--- a/mc/1.20.5/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
+++ b/mc/1.20.5/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
@@ -6,6 +6,7 @@ import com.google.gson.JsonObject;
 import dev.u9g.minecraftdatagenerator.util.DGU;
 import net.minecraft.block.AirBlock;
 import net.minecraft.block.FluidBlock;
+import net.minecraft.block.BubbleColumnBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.item.Item;
@@ -135,7 +136,8 @@ public class BlocksDataGenerator implements IDataGenerator {
         blockDesc.addProperty("hardness", block.getHardness());
         blockDesc.addProperty("resistance", block.getBlastResistance());
         blockDesc.addProperty("stackSize", block.asItem().getMaxCount());
-        blockDesc.addProperty("diggable", block.getHardness() != -1.0f && !(block instanceof AirBlock) && !(block instanceof FluidBlock));
+        boolean nonTargetable = block instanceof AirBlock || block instanceof FluidBlock || block instanceof BubbleColumnBlock;
+        blockDesc.addProperty("diggable", block.getHardness() != -1.0f && !nonTargetable);
 //        JsonObject effTools = new JsonObject();
 //        effectiveTools.forEach(item -> effTools.addProperty(
 //                String.valueOf(Registry.ITEM.getRawId(item)), // key

--- a/mc/1.20/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
+++ b/mc/1.20/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
@@ -5,6 +5,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import dev.u9g.minecraftdatagenerator.util.DGU;
 import net.minecraft.block.AirBlock;
+import net.minecraft.block.FluidBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.item.Item;
@@ -134,7 +135,7 @@ public class BlocksDataGenerator implements IDataGenerator {
         blockDesc.addProperty("hardness", block.getHardness());
         blockDesc.addProperty("resistance", block.getBlastResistance());
         blockDesc.addProperty("stackSize", block.asItem().getMaxCount());
-        blockDesc.addProperty("diggable", block.getHardness() != -1.0f && !(block instanceof AirBlock));
+        blockDesc.addProperty("diggable", block.getHardness() != -1.0f && !(block instanceof AirBlock) && !(block instanceof FluidBlock));
 //        JsonObject effTools = new JsonObject();
 //        effectiveTools.forEach(item -> effTools.addProperty(
 //                String.valueOf(Registry.ITEM.getRawId(item)), // key

--- a/mc/1.20/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
+++ b/mc/1.20/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
@@ -6,6 +6,7 @@ import com.google.gson.JsonObject;
 import dev.u9g.minecraftdatagenerator.util.DGU;
 import net.minecraft.block.AirBlock;
 import net.minecraft.block.FluidBlock;
+import net.minecraft.block.BubbleColumnBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.item.Item;
@@ -135,7 +136,8 @@ public class BlocksDataGenerator implements IDataGenerator {
         blockDesc.addProperty("hardness", block.getHardness());
         blockDesc.addProperty("resistance", block.getBlastResistance());
         blockDesc.addProperty("stackSize", block.asItem().getMaxCount());
-        blockDesc.addProperty("diggable", block.getHardness() != -1.0f && !(block instanceof AirBlock) && !(block instanceof FluidBlock));
+        boolean nonTargetable = block instanceof AirBlock || block instanceof FluidBlock || block instanceof BubbleColumnBlock;
+        blockDesc.addProperty("diggable", block.getHardness() != -1.0f && !nonTargetable);
 //        JsonObject effTools = new JsonObject();
 //        effectiveTools.forEach(item -> effTools.addProperty(
 //                String.valueOf(Registry.ITEM.getRawId(item)), // key

--- a/mc/1.21.3/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
+++ b/mc/1.21.3/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
@@ -5,6 +5,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import dev.u9g.minecraftdatagenerator.util.DGU;
 import net.minecraft.block.AirBlock;
+import net.minecraft.block.FluidBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.item.Item;
@@ -134,7 +135,7 @@ public class BlocksDataGenerator implements IDataGenerator {
         blockDesc.addProperty("hardness", block.getHardness());
         blockDesc.addProperty("resistance", block.getBlastResistance());
         blockDesc.addProperty("stackSize", block.asItem().getMaxCount());
-        blockDesc.addProperty("diggable", block.getHardness() != -1.0f && !(block instanceof AirBlock));
+        blockDesc.addProperty("diggable", block.getHardness() != -1.0f && !(block instanceof AirBlock) && !(block instanceof FluidBlock));
 //        JsonObject effTools = new JsonObject();
 //        effectiveTools.forEach(item -> effTools.addProperty(
 //                String.valueOf(Registry.ITEM.getRawId(item)), // key

--- a/mc/1.21.3/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
+++ b/mc/1.21.3/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
@@ -6,6 +6,7 @@ import com.google.gson.JsonObject;
 import dev.u9g.minecraftdatagenerator.util.DGU;
 import net.minecraft.block.AirBlock;
 import net.minecraft.block.FluidBlock;
+import net.minecraft.block.BubbleColumnBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.item.Item;
@@ -135,7 +136,8 @@ public class BlocksDataGenerator implements IDataGenerator {
         blockDesc.addProperty("hardness", block.getHardness());
         blockDesc.addProperty("resistance", block.getBlastResistance());
         blockDesc.addProperty("stackSize", block.asItem().getMaxCount());
-        blockDesc.addProperty("diggable", block.getHardness() != -1.0f && !(block instanceof AirBlock) && !(block instanceof FluidBlock));
+        boolean nonTargetable = block instanceof AirBlock || block instanceof FluidBlock || block instanceof BubbleColumnBlock;
+        blockDesc.addProperty("diggable", block.getHardness() != -1.0f && !nonTargetable);
 //        JsonObject effTools = new JsonObject();
 //        effectiveTools.forEach(item -> effTools.addProperty(
 //                String.valueOf(Registry.ITEM.getRawId(item)), // key

--- a/mc/1.21/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
+++ b/mc/1.21/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
@@ -5,6 +5,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import dev.u9g.minecraftdatagenerator.util.DGU;
 import net.minecraft.block.AirBlock;
+import net.minecraft.block.FluidBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.item.Item;
@@ -134,7 +135,7 @@ public class BlocksDataGenerator implements IDataGenerator {
         blockDesc.addProperty("hardness", block.getHardness());
         blockDesc.addProperty("resistance", block.getBlastResistance());
         blockDesc.addProperty("stackSize", block.asItem().getMaxCount());
-        blockDesc.addProperty("diggable", block.getHardness() != -1.0f && !(block instanceof AirBlock));
+        blockDesc.addProperty("diggable", block.getHardness() != -1.0f && !(block instanceof AirBlock) && !(block instanceof FluidBlock));
 //        JsonObject effTools = new JsonObject();
 //        effectiveTools.forEach(item -> effTools.addProperty(
 //                String.valueOf(Registry.ITEM.getRawId(item)), // key

--- a/mc/1.21/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
+++ b/mc/1.21/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
@@ -6,6 +6,7 @@ import com.google.gson.JsonObject;
 import dev.u9g.minecraftdatagenerator.util.DGU;
 import net.minecraft.block.AirBlock;
 import net.minecraft.block.FluidBlock;
+import net.minecraft.block.BubbleColumnBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.item.Item;
@@ -135,7 +136,8 @@ public class BlocksDataGenerator implements IDataGenerator {
         blockDesc.addProperty("hardness", block.getHardness());
         blockDesc.addProperty("resistance", block.getBlastResistance());
         blockDesc.addProperty("stackSize", block.asItem().getMaxCount());
-        blockDesc.addProperty("diggable", block.getHardness() != -1.0f && !(block instanceof AirBlock) && !(block instanceof FluidBlock));
+        boolean nonTargetable = block instanceof AirBlock || block instanceof FluidBlock || block instanceof BubbleColumnBlock;
+        blockDesc.addProperty("diggable", block.getHardness() != -1.0f && !nonTargetable);
 //        JsonObject effTools = new JsonObject();
 //        effectiveTools.forEach(item -> effTools.addProperty(
 //                String.valueOf(Registry.ITEM.getRawId(item)), // key

--- a/mc/22w19a/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
+++ b/mc/22w19a/src/main/java/dev/u9g/minecraftdatagenerator/generators/BlocksDataGenerator.java
@@ -5,6 +5,8 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import dev.u9g.minecraftdatagenerator.util.DGU;
 import net.minecraft.block.AirBlock;
+import net.minecraft.block.FluidBlock;
+import net.minecraft.block.BubbleColumnBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.item.Item;
@@ -134,7 +136,8 @@ public class BlocksDataGenerator implements IDataGenerator {
         blockDesc.addProperty("hardness", block.getHardness());
         blockDesc.addProperty("resistance", block.getBlastResistance());
         blockDesc.addProperty("stackSize", block.asItem().getMaxCount());
-        blockDesc.addProperty("diggable", block.getHardness() != -1.0f && !(block instanceof AirBlock));
+        boolean nonTargetable = block instanceof AirBlock || block instanceof FluidBlock || block instanceof BubbleColumnBlock;
+        blockDesc.addProperty("diggable", block.getHardness() != -1.0f && !nonTargetable);
 //        JsonObject effTools = new JsonObject();
 //        effectiveTools.forEach(item -> effTools.addProperty(
 //                String.valueOf(Registry.ITEM.getRawId(item)), // key


### PR DESCRIPTION
This pull request will fix https://github.com/PrismarineJS/minecraft-data/issues/926.

Water, lava, and bubble columns are currently marked as diggable. This causes mineflayer-collect block to try to mine them.
Although water and lava both have a finite hardness, they cannot be targeted. ([minecraft.wiki](https://minecraft.wiki/w/Breaking#Blocks_by_hardness))
![Image](https://github.com/user-attachments/assets/728941ba-e139-4b4a-b696-f11affabfdea)